### PR TITLE
Add lab runbook and fix sweep stubs

### DIFF
--- a/README_LAB.md
+++ b/README_LAB.md
@@ -21,3 +21,21 @@ Over time we will wire:
 - `lab/models/*`                  -> build models given config
 - `lab/metrics/*`                 -> compute metrics from real vs synthetic
 - `lab/compare/*`                 -> build leaderboards and prune runs
+
+## Quick start
+
+- **Phase-0 pipeline (ticks → GRU → synthetic 15s)**
+  ```bash
+  python scripts/run_phase0_pipeline.py
+  ```
+- **Same pipeline via the lab engine (artifacts copied into runs/):**
+  ```bash
+  python scripts/run_phase0_experiment.py
+  ```
+- **Stubbed bars/indicator workflow (creates run folders and metrics placeholders):**
+  ```bash
+  python scripts/run_single.py          # one stub
+  python scripts/run_sweep.py           # small sweep of stub configs
+  ```
+
+For a full tour of the directory layout, run commands, and the next improvements to tackle, see [`docs/LAB_RUNBOOK.md`](docs/LAB_RUNBOOK.md).

--- a/docs/LAB_RUNBOOK.md
+++ b/docs/LAB_RUNBOOK.md
@@ -1,0 +1,82 @@
+# Tickfire Lab Runbook
+
+This runbook captures how the lab is structured today, how to run what already exists, and the next upgrades to prioritize as we scale automated model search for MES price movement.
+
+## Repository map (quick reference)
+
+- `data/` — local-only raw inputs (not versioned)
+  - `rawprice/` — MDP3 tick JSON; source of truth for candles.
+- `out/` — generated artifacts (also local-only)
+  - `bars/` and `bars_indicators/` — prebuilt multi-timeframe bars + indicators.
+- `ml/` — phase-0 reference pipeline (ticks → 15s candles → features → GRU training → generation).
+- `lab/` — evolving experiment platform
+  - `engine/` — orchestrates a run via `run_experiment`.
+  - `features/`, `models/`, `metrics/`, `compare/` — registries and utilities (largely stubs now).
+  - `utils/` — path helpers.
+- `scripts/` — entrypoints for single runs, sweeps, and legacy phase-0 helpers.
+- `runs/` — per-run outputs written by the lab engine (created on demand).
+- `ui/` — placeholder for future visualization (not wired yet).
+
+## How to run what exists today
+
+### 1) Phase-0 (legacy raw tick pipeline)
+
+Use this when you want the known-good GRU reference path that starts from raw MDP3 trades.
+
+```bash
+python scripts/run_phase0_pipeline.py
+```
+
+This simply chains the `ml/` scripts in-place. Make sure the expected raw files are under `data/rawprice/`.
+
+To execute the same logic through the lab engine (so outputs land in `runs/sweeps/...`):
+
+```bash
+python scripts/run_phase0_experiment.py
+```
+
+That wraps `lab.engine.run_experiment` with `experiment_kind="phase0_raw_ml"` and copies artifacts into the run folder.
+
+### 2) Lab engine stubs (bars/indicator workflow)
+
+The future direction is the `bars_multi_tf` workflow, which will consume prebuilt bars/indicators and handle sweeps. The current code is a stub but already produces consistent run folders for downstream tooling.
+
+- Single stub run:
+
+  ```bash
+  python scripts/run_single.py
+  ```
+
+- Stub sweep (three configs with different timeframes/indicator sets/windows):
+
+  ```bash
+  python scripts/run_sweep.py
+  ```
+
+Both commands will write under `runs/sweeps/<sweep_id>/run_*` and emit `config.json`, `status.json`, and `eval/metrics.json` placeholders so we can start building dashboards and comparisons.
+
+### 3) Inspecting structure
+
+For a quick sanity check of directory contents:
+
+```bash
+python scripts/print_structure.py
+```
+
+## Data expectations
+
+- Raw MDP3 trade files live outside of version control in `data/rawprice/` (e.g., `glbx-mdp3-20250318.trades.json`).
+- Derived artifacts (bars, indicators, datasets, generated candles) should also stay untracked under `out/` or `runs/`.
+- The repo ships with no data; ensure local paths match the scripts before running.
+
+## What to improve next (priority list)
+
+1. **Bars+indicator dataset builder** — Implement the `bars_multi_tf` pipeline to read `out/bars/` and `out/bars_indicators/`, assemble feature frames for configurable windows/horizons, and cache datasets under `data/compiled/`.
+2. **Feature palettes** — Fill `lab/features/palettes.py` with concrete palettes (F0–F5) and a helper to materialize them from bar data, including multi-timeframe joins.
+3. **Model registry** — Flesh out `lab/models/registry.py` to instantiate GRU/Transformer variants and surface parameter counts for sweep bookkeeping.
+4. **Metrics + comparisons** — Add return/volatility/shape metrics in `lab/metrics/` and leaderboards in `lab/compare/` so sweeps produce sortable summaries.
+5. **Sweep orchestration** — Extend `scripts/run_sweep.py` to accept CLI/JSON definitions, handle resume/skip, and optionally distribute runs.
+6. **Logging & artifacts** — Standardize per-phase timers, error logging, and artifact manifests (datasets, checkpoints, generated bars) in `run_experiment` outputs.
+7. **UI hook-up** — Point a lightweight viewer (CLI or Streamlit) at `runs/sweeps/**/` to visualize metrics and generated series side-by-side.
+
+As these pieces land, the lab will move from stubbed scaffolding to a repeatable, automated search surface for the best MES price-generation models.

--- a/scripts/run_single.py
+++ b/scripts/run_single.py
@@ -12,10 +12,17 @@ from lab.engine.run_experiment import ExperimentConfig, run_experiment
 
 
 def main():
+    sweep_id = "manual_single"
+    run_dir = Path("runs") / "sweeps" / sweep_id / "run_000_manual_single"
+
     cfg = ExperimentConfig(
         name="manual_single",
-        out_dir=Path("runs") / "sweeps" / "manual_single" / "run_000_manual_single",
+        sweep_id=sweep_id,
+        experiment_kind="bars_multi_tf",
+        data_family="bars_apr07_apr25",
+        out_dir=run_dir,
     )
+
     result = run_experiment(cfg)
     print("[run_single] Experiment completed (stub).")
     print(result)

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -19,16 +19,22 @@ def main():
     configs = [
         ExperimentConfig(
             name=f"{sweep_id}_run_{i:03d}",
-            hidden_size=hs,
-            num_layers=nl,
-            out_dir=base_dir / f"run_{i:03d}_hs{hs}_L{nl}",
+            sweep_id=sweep_id,
+            experiment_kind="bars_multi_tf",
+            data_family=data_family,
+            base_timeframe=base_tf,
+            context_timeframes=context,
+            indicator_set=indicator,
+            window=window,
+            horizon=horizon,
+            out_dir=base_dir
+            / f"run_{i:03d}_{data_family}_{base_tf}_ind{indicator}_w{window}_h{horizon}",
         )
-        for i, (hs, nl) in enumerate(
+        for i, (data_family, base_tf, context, indicator, window, horizon) in enumerate(
             [
-                (64, 1),
-                (64, 2),
-                (128, 1),
-                (128, 2),
+                ("bars_apr07_apr25", "15s", ["5m", "15m"], "full_v1", 256, 1),
+                ("bars_apr07_apr25", "15s", ["5m", "15m"], "basic", 128, 1),
+                ("bars_apr07_apr25", "1m", ["5m", "15m", "1h"], "full_v1", 256, 4),
             ]
         )
     ]


### PR DESCRIPTION
## Summary
- add a lab runbook that documents the project layout, current workflows, and priorities for future improvements
- fix the stub single-run and sweep scripts to build valid ExperimentConfig objects and produce consistent run directories
- extend the lab README with quick-start commands and pointers to the new documentation

## Testing
- python -m compileall scripts lab


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a0e6910e0832da8257d6de254ed15)